### PR TITLE
FIX: FindCalendarHome broken due to typo

### DIFF
--- a/src/CalDAVClient.php
+++ b/src/CalDAVClient.php
@@ -733,7 +733,7 @@ class CalDAVClient {
       }
 
       $calendar_home = array();
-      if (isset($this->xamltags['urn:ietf:params:xml:ns:caldav:calendar-home-set'])) {
+      if (isset($this->xmltags['urn:ietf:params:xml:ns:caldav:calendar-home-set'])) {
           foreach( $this->xmltags['urn:ietf:params:xml:ns:caldav:calendar-home-set'] AS $k => $v ) {
               if ( $this->xmlnodes[$v]['type'] != 'open' ) continue;
               while( $this->xmlnodes[++$v]['type'] != 'close' && $this->xmlnodes[$v]['tag'] != 'urn:ietf:params:xml:ns:caldav:calendar-home-set' ) {


### PR DESCRIPTION
This fixes a tiny typo that caused FindCalendarHome to fail at its job.